### PR TITLE
Simple Android support

### DIFF
--- a/jquery.ui.touch-punch.js
+++ b/jquery.ui.touch-punch.js
@@ -26,10 +26,19 @@
         touchmove:  'mousemove',
         touchend:   'mouseup'
       };
+  
+  function getNativeEvent (event) {
 
+    while(event && typeof event.originalEvent !== "undefined") {
+      event=event.originalEvent;
+    }
+
+    return event;
+  }
+  
   function makeMouseEvent (event) {
 
-    var touch = event.originalEvent.changedTouches[0];
+    var touch = getNativeEvent(event).changedTouches[0];
 
     return $.extend(event, {
       type:    mouseEvents[event.type],

--- a/jquery.ui.touch-punch.js
+++ b/jquery.ui.touch-punch.js
@@ -10,7 +10,7 @@
  */
 (function ($) {
 
-  $.support.touch = typeof Touch === 'object';
+  $.support.touch = "ontouchend" in document;
 
   if (!$.support.touch) {
     return;


### PR DESCRIPTION
Add support for android devices.  This uses a technique I recently saw here: http://code.google.com/p/jquery-ui-for-ipad-and-iphone/

At least for my android phone the code I linked above didn't work for me.  Your code worked great after adding the adjustment to check for touch support.
