### PR TITLE
Ignore browsers without mouse support

### DIFF
--- a/jquery.ui.touch-punch.js
+++ b/jquery.ui.touch-punch.js
@@ -18,6 +18,11 @@
     return;
   }
 
+  // Ignore browsers without mouse support
+  if (!$.ui.mouse) {
+    return;
+  }
+
   var mouseProto = $.ui.mouse.prototype,
       _mouseInit = mouseProto._mouseInit,
       touchHandled;


### PR DESCRIPTION
Some browsers (e.g. PhantomJS) don't have mouse support. Let's ignore them instead of throwing an error on an `undefined ui.mouse.prototype`.
