### PR TITLE
Changes .bind to .on

### DIFF
--- a/jquery.ui.touch-punch.js
+++ b/jquery.ui.touch-punch.js
@@ -149,9 +149,9 @@
 
     // Delegate the touch handlers to the widget's element
     self.element
-      .bind('touchstart', $.proxy(self, '_touchStart'))
-      .bind('touchmove', $.proxy(self, '_touchMove'))
-      .bind('touchend', $.proxy(self, '_touchEnd'));
+      .on('touchstart', $.proxy(self, '_touchStart'))
+      .on('touchmove', $.proxy(self, '_touchMove'))
+      .on('touchend', $.proxy(self, '_touchEnd'));
 
     // Call the original $.ui.mouse init method
     _mouseInit.call(self);


### PR DESCRIPTION
.on will work on newly created elements, .bind will not.  

This will fix some issues I had using jquery-ui-touch-punch with AngularJS.

Plus, "As of jQuery 1.7, the .on() method is the preferred method for attaching event handlers to a document."
