### PR TITLE
Update jquery.ui.touch-punch.js

### DIFF
--- a/jquery.ui.touch-punch.js
+++ b/jquery.ui.touch-punch.js
@@ -80,7 +80,7 @@
     touchHandled = true;
 
     // Track movement to determine if interaction was a click
-    self._touchMoved = false;
+    self._touchMoved = 0;
 
     // Simulate the mouseover event
     simulateMouseEvent(event, 'mouseover');
@@ -103,8 +103,8 @@
       return;
     }
 
-    // Interaction was not a click
-    this._touchMoved = true;
+    // Interaction was less likely to be a click
+    this._touchMoved +=1;
 
     // Simulate the mousemove event
     simulateMouseEvent(event, 'mousemove');
@@ -127,8 +127,8 @@
     // Simulate the mouseout event
     simulateMouseEvent(event, 'mouseout');
 
-    // If the touch interaction did not move, it should trigger a click
-    if (!this._touchMoved) {
+    // If the touch interaction did not move (much), it should trigger a click
+    if (this._touchMoved<=5) {
 
       // Simulate the click event
       simulateMouseEvent(event, 'click');


### PR DESCRIPTION
Allow a little movement before deciding that a touch is not a click (coded to allow 5 move events - but could be a parameter).

This allows sensitive screens (like nexus10) to better register clicks - without this, it is virtually impossible for a user to 'click' as there is always slight movement between touch and release.

The downside is that 'flicking' an item to move it slightly, may register as a click also. The sensitivity could be increased (allow fewer moves between touch and release), or parameterised to make it easily for application users to adjust. Or a genuine move could be de-bounced (if a move happens, any potential click is cancelled).
