### PR TITLE
make sure newly created event for touch has the originalEvent property

### DIFF
--- a/jquery.ui.touch-punch.js
+++ b/jquery.ui.touch-punch.js
@@ -71,8 +71,10 @@
 
     var self = this;
 
+    var touchEvent = $.extend($.Event(event), event.originalEvent.changedTouches[0]);
+
     // Ignore the event if another widget is already being handled
-    if (touchHandled || !self._mouseCapture(event.originalEvent.changedTouches[0])) {
+    if (touchHandled || !self._mouseCapture(touchEvent)) {
       return;
     }
 


### PR DESCRIPTION
I've been using jquery slider with touchpunch, but the absence of the originalEvent property (specifically, the absence of originalEvent.target) makes it impossible to know which DOM element was originally clicked.  This is useful if you want to ensure that you can drag the slider only by a handle.  This change uses the jquery event constructor to build an event with the originalEvent property set to the original touch event.

Andrew
