### PR TITLE
Fixed bug where textareas / inputs didn't trigger keyboard on touch devi...

### DIFF
--- a/jquery.ui.touch-punch.js
+++ b/jquery.ui.touch-punch.js
@@ -35,11 +35,15 @@
       return;
     }
 
-    event.preventDefault();
-
     var touch = event.originalEvent.changedTouches[0],
         simulatedEvent = document.createEvent('MouseEvents');
     
+    if ($(touch.target).is("input") || $(touch.target).is("textarea")) {
+      event.stopPropagation();
+    } else {
+      event.preventDefault();
+    }
+
     // Initialize the simulated mouse event using the touch event's coordinates
     simulatedEvent.initMouseEvent(
       simulatedType,    // type


### PR DESCRIPTION
If the element we are working with is an input or textarea, we use stopPropagation() instead of preventDefault() to preserve focus behavior on the input or textarea
