### PR TITLE
Add support for class to allow srolling through draggable objects.

### DIFF
--- a/jquery.ui.touch-punch.js
+++ b/jquery.ui.touch-punch.js
@@ -35,8 +35,9 @@
       return;
     }
 
-    event.preventDefault();
-
+    if ($(event.currentTarget).hasClass('touch-scroll') === false) {
+        event.preventDefault();
+    }
     var touch = event.originalEvent.changedTouches[0],
         simulatedEvent = document.createEvent('MouseEvents');
     


### PR DESCRIPTION
For carousel type of elements using draggable, this will allow the event's current target to contain an class which will page scrolling "through" the element.
